### PR TITLE
Changed Linux and OpenSuse documentation

### DIFF
--- a/docs/README.linux
+++ b/docs/README.linux
@@ -88,23 +88,35 @@ The command to get the build dependencies, used to compile the version on the PP
 -----------------------------------------------------------------------------
 4. How to compile
 -----------------------------------------------------------------------------
+Cmake build instructions V18.0 Leia and higher
 
-To create the Kodi executable manually perform these steps:
-.0  $ ./bootstrap
+Create and change to build directory 
+    $ mkdir kodi-build && cd kodi-build
+    $ cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local
+    $ cmake --build . -- VERBOSE=1
+    
+Tip: By adding -j<number> to the make command, you describe how many
+     concurrent jobs will be used, it will speed up the build process.
+     So for quadcore the command is:
+    
+    $ cmake --build . -- VERBOSE=1 -j4
 
-.1  $ ./configure <option1> <option2> PREFIX=<system prefix>... (See --help for available options)
-       A full listing of supported options can be viewed by typing './configure --help'.
+If the build process completes succesfully you would want to test if it is working.
+Still in the build directory type the following:
 
-.2  $ make
+    $ ./kodi.bin
+
+If everything was okay during your test you can now install the binaries to their place
+in this example "/usr/local".
+
+    $ sudo make install
+
+This will install Kodi in the prefix provided in 4.1 as well as a launcher script.
 
 Tip: By adding -j<number> to the make command, you describe how many
      concurrent jobs will be used. So for dualcore the command is:
 
-    $ make -j2
-
-.3  $ sudo make install
-
-This will install Kodi in the prefix provided in 4.1 as well as a launcher script.
+    $ sudo make install -j2
 
 Tip: To override the location that Kodi is installed, use PREFIX=<path>.
 For example.

--- a/docs/README.opensuse
+++ b/docs/README.opensuse
@@ -90,10 +90,6 @@ Note: For developers and anyone else who compiles frequently it is recommended t
 -----------------------------------------------------------------------------
 4. How to compile
 -----------------------------------------------------------------------------
-
-To create the Kodi executable manually perform these steps:
-.0  $ ./bootstrap
-
 Cmake build instructions V18.0 and higher OpenSuse
 
 Create and change to build directory 


### PR DESCRIPTION
@wsnipex README.linux now contains cmake compile instructions.
 README.opensuse contains instructions specifically for OpenSuse.

@hudokkow squashed into one commit
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
